### PR TITLE
Add TABS and VALS columns

### DIFF
--- a/R/add-columns.R
+++ b/R/add-columns.R
@@ -37,10 +37,26 @@ get_addcols <- function(group = NULL, con = NULL, spec = NULL) {
   input <- find_column_input(spec = spec, "ADDKOL")
 
   if (!is.na(input)) {
-    args <- is_separate(input, "=")
-    lhs <- is_separate(args[1], ",")
-    rhs <- is_separate(args[2], ",")
-    input <- list(old = lhs, new = rhs)
+    args <- is_separate(input, ",")
+
+    inDT <- vector(mode = "list", length = length(args))
+    for (i in seq_along(args)){
+      addDT <- is_addcols_var(args[i])
+      inDT[[i]] <- addDT
+    }
+
+    cols <- unlist(inDT)
+    lhs <- cols[names(cols) == "old"]
+    rhs <- cols[names(cols) == "new"]
+
+    input <- list(old = unname(lhs), new = unname(rhs))
   }
   return(input)
+}
+
+## Helper funciton ------------------------------
+is_addcols_var <- function(col){
+  lhs <- is_separate(col, "=")[1]
+  rhs <- is_separate(col, "=")[2]
+  list(old = lhs, new = rhs)
 }

--- a/R/org-process.R
+++ b/R/org-process.R
@@ -39,8 +39,8 @@ is_org_process <- function(file,
   manSpec <- get_manheader(spec = filespec)
   dt <- do_manheader(dt, manSpec)
 
-  dataCols <- get_addcols(spec = fgspec)
-  dt <- do_addcols(dt, cols = dataCols)
+  ## dataCols <- get_addcols(spec = fgspec)
+  ## dt <- do_addcols(dt, cols = dataCols)
 }
 
 ## Helper -------------------------------------

--- a/R/read-raw.R
+++ b/R/read-raw.R
@@ -66,11 +66,10 @@ read_raw <- function(group = NULL,
   rowFile <- nrow(spec)
   message(group, " has ", rowFile, " file(s) to be processed...")
 
-  ## COLUMNS TO KEEP -------------------------------------
+  ## COLUMNS TO KEEP ---------------------------------------
   dataCols <- is_data_cols(fgspec = fgSpec)
 
-  ## PROCESS ---------------------------------------------
-
+  ## PROCESS ON FILES IN A FILGRUPPE -----------------------
   DT <- vector(mode = "list", length = rowFile)
   for (i in seq_len(rowFile)) {
     fileSpec <- spec[i, ]
@@ -118,11 +117,17 @@ read_raw <- function(group = NULL,
   }
 
   on.exit(kh$db_close(), add = TRUE)
-  out <- data.table::rbindlist(DT, fill = TRUE)
+  ## DTT <- data.table::rbindlist(DT, fill = TRUE)
 
-  if (save) save_file(dt = out, group = group)
+  ## PROCESS ON FILGRUPPE ----------------------------------
+  grpCols <- get_addcols(spec = fgSpec)
+  outDT <- do_addcols(
+    data.table::rbindlist(DT, fill = TRUE),
+    cols = grpCols)
 
-  return(out)
+  if (save) save_file(dt = outDT, group = group)
+
+  return(outDT)
 }
 
 

--- a/R/recode.R
+++ b/R/recode.R
@@ -1,7 +1,8 @@
 #' @title Recode Variables
 #' @description
 #' Recode variables based on the specification in `tbl_Kode` ie. codebook.
-#' `LESID` is the unique reference to recode variables.
+#' `LESID` must be combined with FILGRUPPE to create a unique reference to
+#' be able to recode variables.
 #' @inheritParams do_split
 #' @inheritParams find_column_input
 #' @inheritParams find_spec

--- a/R/standard-column.R
+++ b/R/standard-column.R
@@ -27,7 +27,6 @@ do_column_standard <- function(dt = NULL, spec = NULL) {
 #' @import data.table
 #' @export
 get_column_standard <- function(group = NULL, con = NULL, spec = NULL) {
-  GEO <- KJONN <- AAR <- ALDER <- UTDANN <- LANDBAK <- VAL <- NULL
 
   is_null_both(group, spec)
   is_not_null_both(group, spec)
@@ -36,12 +35,12 @@ get_column_standard <- function(group = NULL, con = NULL, spec = NULL) {
     spec <- find_spec("filegroups.sql", group, con)
   }
 
-  ## There are 7 standard columns
-  for (i in seq_len(7)) {
-    input <- is_column_na(spec, getOption("orgdata.columns")[i])
+  vars <- getOption("orgdata.columns")
+  for (i in seq_along(vars)) {
+    input <- is_column_na(spec, vars[i])
     assign(input[["col"]], input)
   }
-  x <- data.table::rbindlist(list(GEO, AAR, KJONN, ALDER, UTDANN, LANDBAK, VAL))
+  x <- data.table::rbindlist(mget(vars))
 
   old <- x[!is.na(x$input), ]$input
   new <- x[!is.na(x$input), ]$col

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,8 +1,3 @@
-## Additional options specific to orgdata
-## use getOption("orgdata.folder.db") to get default folder
-## or options(orgdata.db = "dbfile.accdb") to change the filename
-
-
 ## Path for different operating system
 OS <- Sys.info()["sysname"]
 sysDrive <- switch(OS,
@@ -19,10 +14,18 @@ opt.orgdata <- list(
   orgdata.db = "raw-khelse_BE.accdb",
   orgdata.geo = "geo-koder.accdb",
   orgdata.verbose = FALSE,
-  orgdata.columns = c("GEO", "AAR", "KJONN", "ALDER", "UTDANN", "LANDBAK", "VAL"),
-  orgdata.int = c("GEO", "AAR", "KJONN", "ALDER", "VAL"),
   orgdata.aggregate = TRUE,
   orgdata.debug = FALSE,
+
+  ## Standard columns
+  orgdata.columns = c("GEO", "AAR", "KJONN", "ALDER", "UTDANN", "LANDBAK",
+                      "TAB1", "TAB2", "TAB3", "VAL1", "VAL2", "VAL3"),
+
+  ## Columns with integer values
+  orgdata.int = c("GEO", "AAR", "KJONN", "ALDER", "VAL"),
+
+  ## Either to change columnames to standard names or keep as it's.
+  ## Default is to change to standard
   orgdata.active = TRUE
 )
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -22,7 +22,7 @@ opt.orgdata <- list(
                       "TAB1", "TAB2", "TAB3", "VAL1", "VAL2", "VAL3"),
 
   ## Columns with integer values
-  orgdata.int = c("GEO", "AAR", "KJONN", "ALDER", "VAL"),
+  orgdata.int = c("GEO", "AAR", "KJONN", "ALDER", "VAL1"),
 
   ## Either to change columnames to standard names or keep as it's.
   ## Default is to change to standard

--- a/dev/.gitignore
+++ b/dev/.gitignore
@@ -29,3 +29,4 @@ dev-inactive.R
 dev-log.R
 targets.R
 /R
+/code

--- a/dev/TODO.org
+++ b/dev/TODO.org
@@ -58,8 +58,6 @@ Create category that are missing due to NULL based on the standard categories of
 *** TODO TABS and VALS
 - None standards columns in =tbl_innlesing= that needs to be included to output
   table. These columns will again be renamed in =tbl_Filgruppe=.
-*** TODO raw-khelse_FE.accdb
-- Edited version for Frontend. Replace standard =raw-khelse.accdb=
 *** TODO ADDKOL
 - Should read ~TAB1=DIAGNOSE, TAB2=ANTROB~ instead of ~TAB1, TAB2 = DIAGNOSE, ANTROB~ in the current style.
 *** TODO ADDVAL
@@ -72,6 +70,8 @@ Should be a table with files id and dates can be deactivated at once. Steps:
 - Relationship should be 1 in tbl_Orgfile to many in tbl_Koble
 - Update query for koblid and filename
 - Update sub_frm_qrKoble in frm_Overview
-*** TODO Add TABS and VAL
+*** DONE Add TABS and VAL
 - Use VALS 1 to 3 for value columns or columns that have quantity
 - Use TABS 1 to 3 for category variable that aren't standard columns.
+*** TODO raw-khelse_FE.accdb
+- Edited version for Frontend. Replace standard =raw-khelse.accdb=

--- a/dev/TODO.org
+++ b/dev/TODO.org
@@ -62,6 +62,8 @@ Create category that are missing due to NULL based on the standard categories of
 - Should read ~TAB1=DIAGNOSE, TAB2=ANTROB~ instead of ~TAB1, TAB2 = DIAGNOSE, ANTROB~ in the current style.
 *** TODO ADDVAL
 - Need example file to implement this column and what it's for
+*** TODO LESID changed
+- LESID is not unique. It should be combined with FILGRUPPE to make it a unique ID
 ** Access DB
 *** DONE Warning duplicate filename
 Give warning when filename is duplicated in Access register database under =tbl_Orgfile=

--- a/inst/recode.sql
+++ b/inst/recode.sql
@@ -1,3 +1,3 @@
 select FILGRUPPE, LESID, KOL, TYPE, FRA, TIL
 from tbl_Kode
-where FILGRUPPE = '%s' and VERSJONTIL = #9999-01-01# and (LESID is NULL or LESID = %d )
+where FILGRUPPE = '%s' and VERSJONTIL = #9999-01-01# and (LESID is NULL or LESID = '%s')

--- a/inst/specification.sql
+++ b/inst/specification.sql
@@ -3,6 +3,7 @@ FROM tbl_Innlesing
 INNER JOIN (tbl_Koble
             INNER JOIN tbl_Orgfile
             ON tbl_Koble.FILID = tbl_Orgfile.FILID)
-ON (tbl_Innlesing.LESID = tbl_Koble.LESID)
+ON tbl_Koble.LESID = tbl_Innlesing.LESID
+AND tbl_Koble.FILGRUPPE = tbl_Innlesing.FILGRUPPE
 WHERE tbl_Koble.FILGRUPPE = '%s'
 AND tbl_Orgfile.IBRUKTIL = #9999-01-01#


### PR DESCRIPTION
New features:

1. Standard columns include 3 TABS and VALS as in commit 03ab8703. 
2. Input style for `ADDKOL` is seperated with `,` eg. `VAL1=ANTALL, TAB1=ICD`