### PR TITLE
Recode general, common and specified variables

### DIFF
--- a/inst/recode.sql
+++ b/inst/recode.sql
@@ -1,3 +1,3 @@
 select FILGRUPPE, LESID, KOL, TYPE, FRA, TIL
 from tbl_Kode
-where FILGRUPPE = '%s' and VERSJONTIL = #9999-01-01# and (LESID is NULL or LESID = '%s')
+where (FILGRUPPE = '%s' or FILGRUPPE = 'ALLE') and VERSJONTIL = #9999-01-01# and (LESID is NULL or LESID = '%s')

--- a/tests/testthat/setup-test-data.R
+++ b/tests/testthat/setup-test-data.R
@@ -103,30 +103,3 @@ DFout <- structure(list(GEO = c(
 )), row.names = c(NA, -10L), class = "data.frame")
 
 
-### Data for test recode ----------------------------------
-
-recDT <- structure(list(AAR = c(2019L, 2019L, 2019L),
-                        GEO = c(3010105L, 3010105L, 3010202L),
-                        KJONN = c(1L, 1L, 1L),
-                        ALDER = c(67L, 71L, 69L),
-                        UTDANN = 1:3, LANDBAK = c("1B", "0", "0"),
-                        SIVILSTAND = c(2L, 4L, 1L),
-                        VAL = c(1L, 1L, 1L), LANDB = c("1", "0", "0"),
-                        LANDF = c("2", "1", "1")),
-                   row.names = c(NA, -3L), class = c("data.table", "data.frame"
-                                                     ))
-                                        # Codebook
-recCB <- structure(list(FILGRUPPE = c("Dode", "Dode"),
-                        LESID = c(NA, 16L), KOL = c("LANDF", "LANDB"),
-                        TYPE = c(1L, 1L), FRA = c("NA", "0"),
-                        TIL = c("1", "9")),
-                   class = c("data.table", "data.frame"), row.names = c(NA, -2L))
-
-recOut <- structure(list(AAR = c(2019L, 2019L, 2019L),
-                         GEO = c(3010105L, 3010105L, 3010202L),
-                         KJONN = c(1L, 1L, 1L), ALDER = c(67L, 71L, 69L),
-                         UTDANN = 1:3, LANDBAK = c("1B", "0", "0"),
-                         SIVILSTAND = c(2L, 4L, 1L),
-                         VAL = c(1L, 1L, 1L), LANDB = c("1", "9", "9"),
-                         LANDF = c("2", "1", "1")),
-                    row.names = c(NA, -3L), class = c("data.table", "data.frame"))

--- a/tests/testthat/test-recode.R
+++ b/tests/testthat/test-recode.R
@@ -1,5 +1,42 @@
 test_that("Recode variables", {
 
+  ## recode data and spec
+  dtCB <- structure(list(AAR = c(2019L, 2019L, 2019L, 2019L),
+                         LANDBAK = c("1B", "3C", "3B", "0"),
+                         LANDB = c("1", "3", "3", "1"),
+                         LANDF = c("B", "C", "B", "NA")), row.names = c(NA, -4L),
+                    class = c("data.table", "data.frame"))
+
+  specCB <- structure(list(FILGRUPPE = c("ALLE", "test002", "ALLE", "test002", "test002", NA),
+                           LESID = c(NA, NA, NA, "ver02", NA, "ver03"), KOL = c("LANDF", "LANDF", "LANDF", "LANDF", "LANDF", "LANDF"),
+                           TYPE = c(1L, 1L, 1L, 1L, 1L, 1L), FRA = c("B", "C", "NA", "B", "B", "B"),
+                           TIL = c("2", "3", "1", "8", "9", "9")), class = c("data.table", "data.frame"),
+                      row.names = c(NA, -5L))
+
+  ## output lesid
+  outLesid <- structure(list(AAR = c(2019L, 2019L, 2019L, 2019L),
+                             LANDBAK = c("1B", "3C", "3B", "0"),
+                             LANDB = c("1", "3", "3", "1"),
+                             LANDF = c("8", "C", "8", "NA")),
+                        row.names = c(NA, -4L),
+                        class = c("data.table","data.frame"))
+
+  ## output recode_common
+  outCommon <- structure(list(AAR = c(2019L, 2019L, 2019L, 2019L),
+                              LANDBAK = c("1B", "3C", "3B", "0"),
+                              LANDB = c("1", "3", "3", "1"),
+                              LANDF = c("9", "3", "9", "NA")),
+                         row.names = c(NA, -4L),
+                         class = c("data.table","data.frame"))
+
+  ## ouput recode_all
+  outAll <- structure(list(AAR = c(2019L, 2019L, 2019L, 2019L),
+                           LANDBAK = c("1B", "3C", "3B", "0"),
+                              LANDB = c("1", "3", "3", "1"),
+                           LANDF = c("2", "C", "2", "1")),
+                      row.names = c(NA, -4L),
+                         class = c("data.table","data.frame"))
+  ## is_NA
   dtt <- structure(list(VAL = c(1L, 1L), LANDB = c("1", "0"), LANDF = c("B", NA)),
                    row.names = c(NA, -2L), class = c("data.table", "data.frame"))
 
@@ -11,7 +48,9 @@ test_that("Recode variables", {
                          TIL = c("2", "3", "1")),
                     row.names = c(NA, -3L), class = c("data.table", "data.frame"))
 
-  expect_equal(is_recode_lesid(dt = recDT, code = recCB, lesid = 16), recOut)
-  expect_equal(is_recode_common(dt = recDT, code = recCB), recOut)
+  expect_equal(is_recode_lesid(dt = data.table::copy(dtCB), code = specCB, lesid = "ver02"), outLesid)
+  expect_equal(is_recode_common(dt = data.table::copy(dtCB), code = specCB, group = "test002"), outCommon)
+  expect_equal(is_recode_all(dt = data.table::copy(dtCB), code = specCB), outAll)
+  expect_error(is_codebook(cb = specCB))
   expect_equal(is_NA(dt = dtt, code = code, col = "LANDF"), dtout)
 })

--- a/tests/testthat/test-recode.R
+++ b/tests/testthat/test-recode.R
@@ -11,7 +11,7 @@ test_that("Recode variables", {
                          TIL = c("2", "3", "1")),
                     row.names = c(NA, -3L), class = c("data.table", "data.frame"))
 
-  expect_equal(is_recode(dt = recDT, code = recCB, lesid = 16), recOut)
+  expect_equal(is_recode_lesid(dt = recDT, code = recCB, lesid = 16), recOut)
   expect_equal(is_recode_common(dt = recDT, code = recCB), recOut)
   expect_equal(is_NA(dt = dtt, code = code, col = "LANDF"), dtout)
 })


### PR DESCRIPTION
- **General** variables is defined as `ALLE` in FILGRUPPE.
- **Common** variables has specified FILGRUPPE but empty LESID
- **Specific** variables has both specified FILGRUPPE and LESID

**Specific** variables will overrule **Common** variables
**Common** variables will overrule **General** variables