### PR TITLE
Fix #100 enumeration area codes end with `00`

### DIFF
--- a/R/norgeo.R
+++ b/R/norgeo.R
@@ -146,7 +146,7 @@ is_unknown_manucipalty <- function(dt, from, to){
 ## Needs to do it manually comparing the second line with grunnkrets
 ## ends with 00 exist and has missing other geo levels
 is_grunnkrets_00 <- function(dt){
-
+  code <- level <- NULL
   is_verbose(msg = "Searching geo level with NA due to grunnkrets end with 00 ....")
 
   dt <- copy(dt)

--- a/R/norgeo.R
+++ b/R/norgeo.R
@@ -24,7 +24,8 @@ geo_level <- function(year = NULL, append = FALSE, write = FALSE, table = "tblGe
   geo <- KHelse$new(geoFile)
   on.exit(geo$db_close(), add = TRUE)
 
-  geo$tblvalue <- norgeo::cast_geo(year = year)
+  DT <- norgeo::cast_geo(year = year)
+  geo$tblvalue <- is_grunnkrets_00(DT)
   geo$tblname <- table
 
   write <- is_write(write, table, geo$dbconn)
@@ -126,6 +127,8 @@ is_write_msg <- function(msg = c("write", "append", "fetch")){
 is_unknown_manucipalty <- function(dt, from, to){
   oldCode <- currentCode <- NULL
 
+  is_verbose(msg = "Searching for kommune with unknown grunnkrets ...")
+
   kom <- norgeo::track_change("kommune", from = from, to = to)
   kom <- kom[!is.na(oldCode)]
   kom <- kom[, `:=`(oldCode = paste0(oldCode, "9999"),
@@ -136,4 +139,46 @@ is_unknown_manucipalty <- function(dt, from, to){
   kom[, c("oldName", "newName") := "Uoppgitt"]
 
   data.table::rbindlist(list(dt, kom))
+}
+
+
+## Grunnkrets that ends with 00 has no corresponds code from API
+## Needs to do it manually comparing the second line with grunnkrets
+## ends with 00 exist and has missing other geo levels
+is_grunnkrets_00 <- function(dt){
+
+  is_verbose(msg = "Searching geo level with NA due to grunnkrets end with 00 ....")
+
+  dt <- copy(dt)
+  data.table::setkey(dt, code)
+  idx <- dt[, .I[level == "grunnkrets" & code %like% "00$"]]
+  levels <- c("kommune", "fylke","bydel")
+
+  cax <- idx[seq(1, length(idx), 40)]
+  ## pb <- txtProgressBar(min = 0, max = length(idx), style = 3)
+
+  for (i in idx){
+    ## setTxtProgressBar(pb, i)
+    ixrange <- c(i, i + 1)
+    code01 <- sub("\\d{2}$", "", dt[ixrange[1], code])
+    code02 <- sub("\\d{2}$", "", dt[ixrange[2], code])
+
+    same <- identical(code01, code02)
+
+    if (same){
+      dtlike <- dt[ixrange]
+      dt <- is_delete_index(dt, ixrange)
+      for (j in levels) {
+        set(dtlike, which(is.na(dtlike[[j]])), j = j, value = dtlike[2, get(j)])
+      }
+      dt <- data.table::rbindlist(list(dt, dtlike))
+      data.table::setkey(dt, code)
+    }
+
+    if (is.element(i, cax)) cat(".")
+  }
+
+  cat("\n")
+
+  return(dt)
 }

--- a/tests/testthat/test-norgeo-recode.R
+++ b/tests/testthat/test-norgeo-recode.R
@@ -16,3 +16,33 @@ test_that("Add grunnkrets code", {
   expect_equal(is_grunnkrets(dgrk), out)
 
 })
+
+
+test_that("Grunnkrets ends with 00", {
+
+  ## Data ---------
+  input <- structure(list(code = c("03010100", "03010101", "54449900", "54449999"),
+                          name = c("Sentrum 1", "Sentrum 1  - Rode 1", "Uoppgitt delområde", "Uoppgitt grunnkrets"),
+                          validTo = c("2021", "2021", "2021", "2021"),
+                          level = c("grunnkrets", "grunnkrets", "grunnkrets", "grunnkrets"),
+                          grunnkrets = c("03010100", "03010101", "54449900", "54449999"),
+                          kommune = c(NA, "0301", NA, "5444"), fylke = c(NA, "03", NA, "54"),
+                          bydel = c(NA, "030116", NA, NA)),
+                     row.names = c(NA, -4L),
+                     class = c("data.table", "data.frame"), sorted = "code")
+
+  output <- structure(list(code = c("03010100", "03010101", "54449900", "54449999"),
+                           name = c("Sentrum 1", "Sentrum 1  - Rode 1", "Uoppgitt delområde", "Uoppgitt grunnkrets"),
+                           validTo = c("2021", "2021", "2021", "2021"),
+                           level = c("grunnkrets", "grunnkrets", "grunnkrets", "grunnkrets"),
+                           grunnkrets = c("03010100", "03010101", "54449900", "54449999"),
+                           kommune = c("0301", "0301", "5444", "5444"),
+                           fylke = c("03", "03", "54", "54"),
+                           bydel = c("030116", "030116", NA, NA)),
+                      row.names = c(NA, -4L),
+                      class = c("data.table", "data.frame"), sorted = "code")
+
+  ## Test
+  expect_equal(is_grunnkrets_00(input), output)
+
+})


### PR DESCRIPTION
When enumeration area codes ends with `00` it has empty `kommune`, `fylke` and `bydel` because correspond table from API exclude grunnkrets ends with `00` but starts with `01` etc. 