### PR TITLE
Fix #173 Don't loop recode warning messages

### DIFF
--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -61,37 +61,16 @@ do_aggregate <- function(dt = NULL,
   ## and INNVKAT
   if (any(names(dt) == "LANDSSB")) dt[, LANDSSB := NULL]
 
-  is_verbose(msg = is_line_short(), type = "other", ctrl = FALSE)
   msg <- paste0("Starts aggregating data from ", source, " to")
   is_verbose(x = level, msg = msg, ctrl = FALSE)
 
   colVals <- paste0("VAL", 1:getOption("orgdata.vals"))
-  aggNot <- c("GEO", colVals)
+  aggNot <- c("GEO", colVals, "origin", "dummy_grk")
   aggYes <- setdiff(names(dt), aggNot)
   aggCols <- c(level, aggYes)
 
   geoFile <- is_path_db(getOption("orgdata.geo"), check = TRUE)
-  geoDB <- KHelse$new(geoFile)
-
-  ## validTo in the database `tblGeo` is a character
-
-  if (is.null(year)){
-    year <- as.integer(format(Sys.Date(), "%Y"))
-  }
-
-  ## recode GEO codes
-  code <- get_geo_recode(con = geoDB$dbconn, type = source, year = year)
-  dt <- do_geo_recode(dt = dt,
-                      code = code,
-                      type = source,
-                      year = year,
-                      con = geoDB$dbconn,
-                      base = base,
-                      control = control)
-
-  if (getOption("orgdata.debug.geo")){
-    return(dt)
-  }
+  geoDB <- is_conn_db(geoFile)
 
   ## Cast geo levels ie. aggregate to different geo levels
   geoDT <- find_spec(

--- a/R/make-file.R
+++ b/R/make-file.R
@@ -99,6 +99,8 @@ make_file <- function(group = NULL,
       control = fileCtrl
     )
 
+    is_verbose(msg = is_line_short(), type = "other", ctrl = FALSE)
+
     ## Keep columname as TAB1 to 3 and VAL1 to 3 as defined in Access coz
     ## aggregating uses the standard columnames for id and measure variables
     dt <- do_reshape_rename_col(dt = dt, spec = fileSpec)
@@ -148,6 +150,8 @@ make_file <- function(group = NULL,
 
   geoLevel <- get_aggregate(spec = fgSpec)
 
+  is_verbose(msg = is_line_short(), type = "other", ctrl = FALSE)
+
   if (implicitnull){
     for(gg in geoLevel){
       dtsub <- outDT[LEVEL == gg]
@@ -165,6 +169,7 @@ make_file <- function(group = NULL,
   grpCols <- get_colname(spec = fgSpec)
   outDT <- do_colname(dt = outDT, cols = grpCols)
 
+  is_verbose(msg = is_line_short(), type = "other", ctrl = FALSE)
   outDT <- do_recode_aggregate(dt = outDT,
                                spec = fileSpec,
                                con = kh$dbconn,

--- a/R/utils-read-org.R
+++ b/R/utils-read-org.R
@@ -57,6 +57,31 @@ is_aggregate <- function(dt = NULL,
   source <- is_geo_level(dt[!is.na(GEO), GEO][1])
   aggCol <- find_column_multi(spec = fgspec, "AGGKOL") #Other columns to aggregate
 
+  geoFile <- is_path_db(getOption("orgdata.geo"), check = TRUE)
+  geoDB <- is_conn_db(geoFile)
+
+  ## validTo in the database `tblGeo` is a character
+
+  if (is.null(year)){
+    year <- as.integer(format(Sys.Date(), "%Y"))
+  }
+
+  ## recode GEO codes
+  code <- get_geo_recode(con = geoDB$dbconn, type = source, year = year)
+  dt <- do_geo_recode(dt = dt,
+                      code = code,
+                      type = source,
+                      year = year,
+                      con = geoDB$dbconn,
+                      base = base,
+                      control = control)
+
+  is_verbose(msg = is_line_short(), type = "other", ctrl = FALSE)
+
+  if (getOption("orgdata.debug.geo")){
+    return(dt)
+  }
+
   if (aggregate){
     nSpec <- length(aggSpec)
     DT <- vector(mode = "list", length = nSpec)


### PR DESCRIPTION
When aggregate to different geo levels, recode warning should
only shown once and not by each geo levels selected.