### PR TITLE
Fix #181 use unknown codes created from municipality for grunnkrets and bydel

### DIFF
--- a/R/norgeo-recode.R
+++ b/R/norgeo-recode.R
@@ -312,7 +312,7 @@ is_problem_geo_before_2002 <- function(dt, dcode, type, year, con){
   # dcode - Problem codes
   # type - grunnkrets or bydel
 
-  GEO <- Geo_Dummy <- NULL
+  GEO <- Geo_Dummy <- oldCode <- currentCode <- i.newGEO <- newGEO <- NULL
   yr <- unique(dt$AAR)
 
   yrOld <- any(yr < 2003)


### PR DESCRIPTION
Instead of using the Excel file from SSB for grunnkrets code change before 2002, create a dummy code from unknown codes derived from municipality code with added `xxxx99` or `xxxx9999`