### PR TITLE
Close #223 limit core to 50% when parallel process

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orgdata
 Title: Aggregating Original Data
-Version: 0.5.0
+Version: 0.5.1
 Authors@R:
     person(given = "Yusman",
            family = "Kamaleri",
@@ -32,6 +32,7 @@ Imports:
     listenv (>= 0.8.0),
     future.apply (>= 1.8.1),
     progressr (>= 0.10.0),
+    parallel (>= 4.1.1),
     parallelly (>= 1.30.0),
     withr (>= 2.4.3)
 Remotes: helseprofil/norgeo

--- a/R/make-file.R
+++ b/R/make-file.R
@@ -7,16 +7,16 @@
 #' @description The function [lag_fil()] is an alias to [make_file()].
 #' @param group The group of files (\emph{filgruppe})
 #' @param koblid \code{KOBLID} from table \emph{tbl_Koble}
-#' @param aggregate Logical argument. Default is `TRUE`. Aggregate data
+#' @param aggregate Logical value. Default is `TRUE`. Aggregate data
 #'   according to the specification in registration database. Global options
 #'   with `orgdata.aggregate`.
 #' @param save Save as `.csv` by activating `save_file()`. Default is `FALSE`
 #' @inheritParams do_aggregate
-#' @param implicitnull Logical argument. Default is `TRUE` to add implicit null
+#' @param implicitnull Logical value. Default is `TRUE` to add implicit null
 #'   to the dataset. Global options with `orgdata.implicit.null`.
 #' @param row Select only specify row(s). Useful for debugging
 #' @inheritParams do_geo_recode
-#' @param parallel Logical argument. Either to run with parallel or not. Default
+#' @param parallel Logical value. Either to run with parallel or not. Default
 #'   is `FALSE`
 #' @aliases make_file lag_fil
 #' @examples
@@ -36,7 +36,7 @@ make_file <- function(group = NULL,
                       implicitnull = getOption("orgdata.implicit.null"),
                       row = getOption("orgdata.debug.row"),
                       base = getOption("orgdata.recode.base"),
-                      parallel = FALSE
+                      parallel = getOption("orgdata.parallel")
                       ) {
 
   LEVEL <- NULL
@@ -85,7 +85,17 @@ make_file <- function(group = NULL,
 
   ## PROCESS ON FILES LEVEL IN A FILGRUPPE -----------------------
   if(parallel){
-    is_verbose(msg = "Start parallel processing ...")
+
+    ## Use 50% of the cores on the system
+    options(parallelly.availableCores.custom = function() {
+      ncores <- max(parallel::detectCores(), 1L, na.rm = TRUE)
+      ncores <- min(as.integer(0.50 * ncores))
+      max(1L, ncores)
+    })
+    paraMsg1 <- paste0("Start parallel processing ... \U001F680")
+    paraMsg <- paste0("Start parallel processing with ", parallelly::availableCores(), " cores \U001F680")
+    is_verbose(msg = paraMsg)
+
     future::plan(future::multisession)
     p <- progressr::progressor(steps = rowFile)
     ## p <- progressr::progressor(along = seq_len(rowFile))

--- a/R/make-group.R
+++ b/R/make-group.R
@@ -19,6 +19,11 @@ make_filegroups <- function(...){
   options(orgdata.verbose = FALSE)
   on.exit(reset_opt())
 
+  para <- utils::askYesNo("Do you want to run parallelly?")
+  if (para){
+    withr::local_options(list(orgdata.parallel = TRUE))
+  }
+
   fgp <- tryCatch({
     unlist(list(...))
   },
@@ -38,7 +43,7 @@ make_filegroups <- function(...){
 
     FGP <- tryCatch({
       is_color_txt(i, msg = "Processing:")
-      make_file(i, save = TRUE, parallel = TRUE)
+      make_file(i, save = TRUE, parallel = getOption("orgdata.parallel"))
     },
       error = function(err) err)
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -17,6 +17,7 @@ opt.orgdata <- list(
   orgdata.aggregate = TRUE,
   orgdata.implicit.null = TRUE,
   orgdata.recode.base = FALSE,
+  orgdata.parallel = FALSE,
 
   ## Number of TABS and VALS
   orgdata.tabs = 3,
@@ -50,5 +51,5 @@ opt.orgdata <- list(
 }
 
 .onAttach <- function(libname, pkgname) {
-  packageStartupMessage("orgdata version 0.5.0")
+  packageStartupMessage("orgdata version 0.5.1")
 }

--- a/man/do_make_file_each.Rd
+++ b/man/do_make_file_each.Rd
@@ -11,7 +11,7 @@ do_make_file_each(spec, fgspec, aggregate, datacols, year, row, base)
 
 \item{fgspec}{Filegroup specification}
 
-\item{aggregate}{Logical argument. Default is \code{TRUE}. Aggregate data
+\item{aggregate}{Logical value. Default is \code{TRUE}. Aggregate data
 according to the specification in registration database. Global options
 with \code{orgdata.aggregate}.}
 

--- a/man/do_recode_aggregate.Rd
+++ b/man/do_recode_aggregate.Rd
@@ -19,7 +19,7 @@ do_recode_aggregate(
 
 \item{con}{Connection to database}
 
-\item{aggregate}{Logical argument. Default is \code{TRUE}. Aggregate data
+\item{aggregate}{Logical value. Default is \code{TRUE}. Aggregate data
 according to the specification in registration database. Global options
 with \code{orgdata.aggregate}.}
 

--- a/man/make_file.Rd
+++ b/man/make_file.Rd
@@ -14,7 +14,7 @@ make_file(
   implicitnull = getOption("orgdata.implicit.null"),
   row = getOption("orgdata.debug.row"),
   base = getOption("orgdata.recode.base"),
-  parallel = FALSE
+  parallel = getOption("orgdata.parallel")
 )
 
 lag_fil(
@@ -26,7 +26,7 @@ lag_fil(
   implicitnull = getOption("orgdata.implicit.null"),
   row = getOption("orgdata.debug.row"),
   base = getOption("orgdata.recode.base"),
-  parallel = FALSE
+  parallel = getOption("orgdata.parallel")
 )
 }
 \arguments{
@@ -34,7 +34,7 @@ lag_fil(
 
 \item{koblid}{\code{KOBLID} from table \emph{tbl_Koble}}
 
-\item{aggregate}{Logical argument. Default is \code{TRUE}. Aggregate data
+\item{aggregate}{Logical value. Default is \code{TRUE}. Aggregate data
 according to the specification in registration database. Global options
 with \code{orgdata.aggregate}.}
 
@@ -43,7 +43,7 @@ with \code{orgdata.aggregate}.}
 \item{year}{Which year of georaphical code to use for recoding and
 aggregating. If not specified, then current year will be used}
 
-\item{implicitnull}{Logical argument. Default is \code{TRUE} to add implicit null
+\item{implicitnull}{Logical value. Default is \code{TRUE} to add implicit null
 to the dataset. Global options with \code{orgdata.implicit.null}.}
 
 \item{row}{Select only specify row(s). Useful for debugging}
@@ -52,7 +52,7 @@ to the dataset. Global options with \code{orgdata.implicit.null}.}
 year to recode the geographical codes. Default is \code{FALSE} and use all
 available codes in geo codebook}
 
-\item{parallel}{Logical argument. Either to run with parallel or not. Default
+\item{parallel}{Logical value. Either to run with parallel or not. Default
 is \code{FALSE}}
 }
 \description{

--- a/tests/testthat/test-make-file.R
+++ b/tests/testthat/test-make-file.R
@@ -3,7 +3,7 @@ test_that("Make file simple", {
   testthat::skip_on_covr()
   testthat::skip_on_ci()
   testthat::skip_on_cran()
-  skip_if_check(local = )
+  skip_if_check()
   simpleDT <- readRDS(system.file("testdata_dev", "make-file-dt.rds", package = "orgdata"))
   leseOUT <- readRDS(system.file("testdata_dev", "make-file2-dt.rds", package = "orgdata"))
   debug_opt("nrow", 500)


### PR DESCRIPTION
It's either MS Access that doesn't handle parallel processing or something else. In case it's due to the need of MS Access to use the available cores as well so it's an alternative to limit parallel to only 4 cores