### PR TITLE
only set encoding=orgdata.encoding.csv if encoding not specified

### DIFF
--- a/R/find-data.R
+++ b/R/find-data.R
@@ -31,7 +31,9 @@ find_data.csv <- function(file, ...) {
   dots <- is_csv_dots(...)
   is_verbose(file, msg = "File:")
   dots$file <- file
+  if(is.null(dots$encoding)){
   dots$encoding <- getOption("orgdata.encoding.csv")
+  }
   dt <- do.call(data.table::fread, dots)
 }
 


### PR DESCRIPTION
It was not possible to set encoding in read_file(), as it was always overwritten in find_data.csv to orgdata.encoding.csv