### PR TITLE
temporarily add option to work on HDIR

### DIFF
--- a/R/utils-misc.R
+++ b/R/utils-misc.R
@@ -216,3 +216,14 @@ is_correct_globs <- function(x){
   y <- names(x)[names(x) %in% names(options())]
   all.equal(x[y], options()[y])
 }
+
+#' Temporary fix to run on HDIR systems 
+#'
+#' @export
+#'
+#' @examples
+run_orgdata_hdir <- function(){
+  options(orgdata.win.drive = "O:")
+  options(orgdata.folder.db = "Prosjekt/FHP/PRODUKSJON/STYRING/raw-khelse")
+  options(orgdata.folder.data = "Prosjekt/FHP/PRODUKSJON/ORGDATA")
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -17,6 +17,11 @@ opt.orgdata <- is_globs()
       update_globs()
     }
   }
+  
+  hdir <- utils::askYesNo("Are you running orgdata on a HDIR computer?")
+  if(isTRUE(hdir)){
+    run_orgdata_hdir()
+  }
 
   invisible()
 }


### PR DESCRIPTION
Before moving everything to HDIR, the system needs to work on both FHI and HDIR platforms. The function `run_orgdata_hdir()` changes the paths in options to point to `O:/...` instead of `F:/...`